### PR TITLE
skip parsing commits from dependency materials

### DIFF
--- a/lib/go_api_client/pipeline.rb
+++ b/lib/go_api_client/pipeline.rb
@@ -28,7 +28,7 @@ module GoApiClient
       self.url        = href_from(@root.xpath("./link[@rel='self']"))
       self.identifier = @root.xpath("./id").first.content
       self.schedule_time = Time.parse(@root.xpath('./scheduleTime').first.content).utc
-      self.commits    = @root.xpath("./materials/material/modifications/changeset").collect do |changeset|
+      self.commits    = @root.xpath('./materials/material[@type != "DependencyMaterial"]/modifications/changeset').collect do |changeset|
         Commit.new(changeset).parse!
       end
 


### PR DESCRIPTION
I used the go-api-client and when I parsed this feed: https://go01.thoughtworks.com/go/api/pipelines/GreenInstallers/122316.xml it blew up parsing the commit because it was not a real commit, it was part of a dependency material. I don't know why Go represents them as changesets and maybe you want to model them in your domain specifically but for now I'm just skipping parsing them so I can use it.
