### PR TITLE
Only parse commits of type GitMaterial.

### DIFF
--- a/lib/go_api_client/pipeline.rb
+++ b/lib/go_api_client/pipeline.rb
@@ -28,7 +28,7 @@ module GoApiClient
       self.url        = href_from(@root.xpath("./link[@rel='self']"))
       self.identifier = @root.xpath("./id").first.content
       self.schedule_time = Time.parse(@root.xpath('./scheduleTime').first.content).utc
-      self.commits    = @root.xpath("./materials/material/modifications/changeset").collect do |changeset|
+      self.commits    = @root.xpath('./materials/material[@type = "GitMaterial"]/modifications/changeset').collect do |changeset|
         Commit.new(changeset).parse!
       end
 

--- a/test/go_api_client/pipeline_test.rb
+++ b/test/go_api_client/pipeline_test.rb
@@ -30,5 +30,55 @@ module GoApiClient
       assert_equal [author_foo, author_bar], pipeline.authors
     end
 
+    test "should only parse materials with type=GitMaterial" do
+      doc = Nokogiri::XML.parse %q{<?xml version="1.0" encoding="UTF-8"?>
+
+        <pipeline name="GreenInstallers" counter="286" label="286">
+          <link rel="self" href="https://go.example.com/go/api/pipelines/GreenInstallers/122316.xml"/>
+          <id><![CDATA[urn:x-go.studios.thoughtworks.com:job-id:GreenInstallers:286]]></id>
+          <link rel="insertedBefore" href="https://go.example.com/go/api/pipelines/GreenInstallers/122309.xml"/>
+          <link rel="insertedAfter" href="https://go.example.com/go/api/pipelines/GreenInstallers/122286.xml"/>
+          <scheduleTime>2013-02-08T20:34:12-08:00</scheduleTime>
+          <materials>
+            <material materialUri="https://go.example.com/go/api/materials/5185.xml" type="GitMaterial" url="git@github.com:test-repo.git" branch="master">
+              <modifications>
+                <changeset changesetUri="https://go.example.com/go/api/materials/5185/changeset/bc9cc9401b816d753f267227934e535affcb4028.xml">
+                  <user><![CDATA[wdephill <wdephill@thoughtworks.com>]]></user>
+                  <checkinTime>2013-02-08T16:19:18-08:00</checkinTime>
+                  <revision><![CDATA[bc9cc9401b816d753f267227934e535affcb4028]]></revision>
+                  <message><![CDATA[ #14163 - [WYSIWYG] Column layout. Use plugin onchange to ensure that there is an empty p at the end of the doc so that you can get out of the column.]]></message>
+                  <file name="public/javascripts/ckeditor/config.js" action="modified"/>
+                  <file name="public/javascripts/ckeditor/plugins/onchange/docs/install.html" action="added"/>
+                  <file name="public/javascripts/ckeditor/plugins/onchange/docs/styles.css" action="added"/>
+                  <file name="public/javascripts/ckeditor/plugins/onchange/plugin.js" action="added"/>
+                </changeset>
+              </modifications>
+            </material>
+            <material materialUri="https://go.example.com/go/api/materials/30536.xml" type="DependencyMaterial" pipelineName="IE8-PostgreSQL9" stageName="Acceptances">
+              <modifications>
+                <changeset changesetUri="https://go.example.com/go/api/stages/264242.xml">
+                  <checkinTime>2013-02-08T20:33:45-08:00</checkinTime>
+                  <revision>IE8-PostgreSQL9/942/Acceptances/1</revision>
+                </changeset>
+              </modifications>
+            </material>
+          </materials>
+          <stages>
+            <stage href="https://go.example.com/go/api/stages/264258.xml"/>
+            <stage href="https://go.example.com/go/api/stages/264271.xml"/>
+          </stages>
+          <approvedBy><![CDATA[changes]]></approvedBy>
+        </pipeline>
+      }
+
+      pipeline = GoApiClient::Pipeline.new(doc.root).parse!
+      assert_equal 1, pipeline.commits.count
+      commit = pipeline.commits.first
+
+      assert_equal 'bc9cc9401b816d753f267227934e535affcb4028',        commit.revision
+      assert_equal User.new('wdephill', 'wdephill@thoughtworks.com'), commit.user
+      assert_equal Time.parse("2013-02-09 00:19:18 UTC"),             commit.time
+    end
+
   end
 end


### PR DESCRIPTION
This is so that we don't have to deal with materials of other types tfs, svn, hg, dependencies et.al.
